### PR TITLE
Ruby CI fix

### DIFF
--- a/.github/workflows/pr-test-ruby-ci.yml
+++ b/.github/workflows/pr-test-ruby-ci.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         go-version: '^1.14'
     - name: Install Protoc
-      uses: arduino/setup-protoc@7ad700d3b20e2a32b35d2c17fbdc463891608381
+      uses: arduino/setup-protoc@v1
       with:
         version: '3.x'
     - name: Install protoc-gen-go


### PR DESCRIPTION
Fixes: CI
## Description of what your PR accomplishes:
[Ruby тест](https://github.com/covid-tracing-mongolia/backend-server/runs/1451202555?check_suite_focus=true)  "Install protoc" шатан дээр ажиллахгүй байсныг засав.
## Why this approach? Any notable design decisions?
--
## Anything the reviewers should focus on? Any discussion points?
Тестууд одоогоор буруу package дээр ажиллаж байна. #3 merge хийвэл зөв ажиллах байх.
