### PR TITLE
Updated MCC to 428 - which is for Mongolia

### DIFF
--- a/.github/workflows/pr-test-ruby-ci.yml
+++ b/.github/workflows/pr-test-ruby-ci.yml
@@ -52,7 +52,7 @@ jobs:
         DB_NAME: test
         DB_PORT: 3306
         ECDSA_KEY: 30770201010420a6885a310b694b7bb4ba985459de1e79446dddcd1247c62ece925402b362a110a00a06082a8648ce3d030107a1440342000403eb64f714c4b4ed394331c26c31b7ce7156d00fb28982ad2679a87eaa1a3869802fbeb1d7ee28002762921929c3f7603672d535fcac3d24d57afbb4e2d97f5a
-        KEY_CLAIM_TOKEN: thisisaverylongtoken=302
+        KEY_CLAIM_TOKEN: thisisaverylongtoken=428
         RETRIEVE_HMAC_KEY: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
         METRICS_USERNAME: 1234567890
         METRICS_PASSWORD: 1234567890

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ Run `make` or `make release` to build a release version of the servers.
 ```bash
 # example...
 export DATABASE_URL="root@tcp(localhost)/covidshield"
-export KEY_CLAIM_TOKEN=thisisatoken=302
+export KEY_CLAIM_TOKEN=thisisatoken=428
 
 ./build/release/key-retrieval migrate-db
 
@@ -69,7 +69,7 @@ PORT=8000 ./build/release/key-submission
 PORT=8001 ./build/release/key-retrieval
 ```
 
-Note that 302 is a [MCC](https://www.mcc-mnc.com/): 302 represents Canada.
+Note that 428 is a [MCC](https://www.mcc-mnc.com/): 428 represents Mongolia.
 
 <h3 id="run-tests">3. Run tests</h3>
 
@@ -160,7 +160,7 @@ Exécuter `make` ou `make release` pour créer une version des serveurs.
 ```bash
 # example...
 export DATABASE_URL="root@tcp(localhost)/covidshield"
-export KEY_CLAIM_TOKEN=thisisatoken=302
+export KEY_CLAIM_TOKEN=thisisatoken=428
 
 ./build/release/key-retrieval migrate-db
 
@@ -168,7 +168,7 @@ PORT=8000 ./build/release/key-submission
 PORT=8001 ./build/release/key-retrieval
 ```
 
-Notez que 302 est un [MCC](https://www.mcc-mnc.com/) : 302 représente le Canada.
+Notez que 428 est un [MCC](https://www.mcc-mnc.com/) : 428 représente le Mongolia.
 
 <h3 id="run-tests">3. Réaliser des tests</h3>
 

--- a/config.yaml
+++ b/config.yaml
@@ -31,4 +31,4 @@ corsAccessControlAllowOrigin: "*"
 disableCurrentDateCheckFeatureFlag: true
 enableEntirePeriodBundle: true
 
-regionCode: "302"
+regionCode: "428"

--- a/examples/retrieval/app.rb
+++ b/examples/retrieval/app.rb
@@ -35,7 +35,7 @@ end
 
 class App
   KEY_RETRIEVAL_URL = "http://127.0.0.1:8001"
-  REGION = '302'
+  REGION = '428'
 
   def initialize
     @database = Database.new

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -64,7 +64,8 @@ func setDefaults() {
 	viper.SetDefault("corsAccessControlAllowOrigin", "*")
 	viper.SetDefault("disableCurrentDateCheckFeatureFlag", true)
 	viper.SetDefault("enableEntirePeriodBundle", false)
-	/// The MCC Region Code for Canada
-	viper.SetDefault("regionCode", "302")
+	/// The MCC Region Code for Mongolia
+	/// https://www.mcc-mnc.com/
+	viper.SetDefault("regionCode", "428")
 	viper.SetDefault("eventQueryRangeDates", 10)
 }

--- a/pkg/keyclaim/authenticator_test.go
+++ b/pkg/keyclaim/authenticator_test.go
@@ -21,35 +21,35 @@ func TestNewAuthenticator(t *testing.T) {
 	os.Setenv("KEY_CLAIM_TOKEN", "foobaz")
 	assert.PanicsWithValue(t, "invalid KEY_CLAIM_TOKEN", func() { NewAuthenticator() }, "KEY_CLAIM_TOKEN must include a `=` and have "+fmt.Sprint(config.AppConstants.AssignmentParts)+"parts")
 
-	os.Setenv("KEY_CLAIM_TOKEN", strings.Repeat("a", 64)+"=302")
+	os.Setenv("KEY_CLAIM_TOKEN", strings.Repeat("a", 64)+"=428")
 	assert.PanicsWithValue(t, "token too long", func() { NewAuthenticator() }, "KEY_CLAIM_TOKEN must include secret that is at less than 64 characters long")
 
-	os.Setenv("KEY_CLAIM_TOKEN", strings.Repeat("a", 19)+"=302")
+	os.Setenv("KEY_CLAIM_TOKEN", strings.Repeat("a", 19)+"=428")
 	assert.PanicsWithValue(t, "token too short", func() { NewAuthenticator() }, "KEY_CLAIM_TOKEN must include secret that is at least 20 characters long")
 
 	os.Setenv("KEY_CLAIM_TOKEN", strings.Repeat("a", 20)+"="+strings.Repeat("a", 32))
 	assert.PanicsWithValue(t, "region too long", func() { NewAuthenticator() }, "KEY_CLAIM_TOKEN must include a region that is less than 32 characters long")
 
 	tokens := make(map[string]string)
-	tokens[strings.Repeat("a", 20)] = "302"
-	tokens[strings.Repeat("b", 20)] = "302"
+	tokens[strings.Repeat("a", 20)] = "428"
+	tokens[strings.Repeat("b", 20)] = "428"
 	expected := &authenticator{tokens: tokens}
 
-	os.Setenv("KEY_CLAIM_TOKEN", strings.Repeat("a", 20)+"=302:"+strings.Repeat("b", 20)+"=302")
+	os.Setenv("KEY_CLAIM_TOKEN", strings.Repeat("a", 20)+"=428:"+strings.Repeat("b", 20)+"=428")
 	assert.Equal(t, expected, NewAuthenticator(), "Returns an authenticator struct with a map of valid tokens and regions")
 }
 
 func TestAuthenticate(t *testing.T) {
 
 	// Initialise Authenticator object
-	os.Setenv("KEY_CLAIM_TOKEN", strings.Repeat("a", 20)+"=302:"+strings.Repeat("b", 20)+"=302")
+	os.Setenv("KEY_CLAIM_TOKEN", strings.Repeat("a", 20)+"=428:"+strings.Repeat("b", 20)+"=428")
 	authenticator := NewAuthenticator()
 
 	// Valid token
-	expectedRegion := "302"
+	expectedRegion := "428"
 	expectedBool := true
 	receivedRegion, receivedBool := authenticator.Authenticate(strings.Repeat("a", 20))
-	assert.Equal(t, expectedRegion, receivedRegion, "Expected region is 302 on valid")
+	assert.Equal(t, expectedRegion, receivedRegion, "Expected region is 428 on valid")
 	assert.Equal(t, expectedBool, receivedBool, "Expected bool is true on invalid token")
 
 	// Invalid token

--- a/pkg/persistence/db_test.go
+++ b/pkg/persistence/db_test.go
@@ -119,7 +119,7 @@ func TestDBClaimKey(t *testing.T) {
 }
 
 const (
-	region     string = "302"
+	region     string = "428"
 	originator string = "randomOrigin"
 )
 
@@ -303,7 +303,7 @@ func TestNeverSucceedsWithDuplicateCodes(t *testing.T) {
 			`INSERT INTO encryption_keys
 		(region, originator, server_private_key, server_public_key, one_time_code, remaining_keys)
 		VALUES (?, ?, ?, ?, ?, ?)`).WithArgs(
-			"302",
+			"428",
 			originator,
 			AnyType{},
 			AnyType{},
@@ -496,7 +496,7 @@ func TestDBStoreKeys(t *testing.T) {
 	}
 
 	pub, _, _ := box.GenerateKey(rand.Reader)
-	region := "302"
+	region := "428"
 	originator := "randomOrigin"
 
 	keyOne := randomTestKey()
@@ -506,7 +506,7 @@ func TestDBStoreKeys(t *testing.T) {
 	hourOfSubmission := timemath.HourNumber(time.Now())
 
 	mock.ExpectBegin()
-	row := sqlmock.NewRows([]string{"region", "originator", "remaining_keys"}).AddRow("302", "randomOrigin", 3)
+	row := sqlmock.NewRows([]string{"region", "originator", "remaining_keys"}).AddRow("428", "randomOrigin", 3)
 	mock.ExpectQuery(`SELECT region, originator, remaining_keys FROM encryption_keys WHERE app_public_key = ? FOR UPDATE`).WillReturnRows(row)
 
 	mock.ExpectPrepare(
@@ -570,14 +570,14 @@ func TestDBFetchKeysForHours(t *testing.T) {
 	}
 
 	// No errors
-	region := "302"
+	region := "428"
 	startHour := uint32(100)
 	endHour := uint32(200)
 	currentRollingStartIntervalNumber := int32(2651450)
 	rollingPeriod := int32(144)
 	transmissionRiskLevel := int32(4)
 
-	row := sqlmock.NewRows([]string{"region", "key_data", "rolling_start_interval_number", "rolling_period", "transmission_risk_level"}).AddRow("302", []byte{}, 2651450, 144, 4)
+	row := sqlmock.NewRows([]string{"region", "key_data", "rolling_start_interval_number", "rolling_period", "transmission_risk_level"}).AddRow("428", []byte{}, 2651450, 144, 4)
 	mock.ExpectQuery("").WillReturnRows(row)
 
 	expectedResult := []*pb.TemporaryExposureKey{

--- a/pkg/persistence/events.go
+++ b/pkg/persistence/events.go
@@ -36,7 +36,7 @@ func translateToken(token string) string {
 	region, ok := originatorLookup.Authenticate(token)
 
 	// If we forgot to map a token to a PT just return the token
-	if region == "302" {
+	if region == "428" {
 		return token
 	}
 
@@ -52,7 +52,7 @@ func translateToken(token string) string {
 func translateTokenForLogs(token string) string {
 	region, ok := originatorLookup.Authenticate(token)
 
-	if region == "302" || ok == false {
+	if region == "428" || ok == false {
 		return fmt.Sprintf("%s...%s", token[0:1], token[len(token)-1:])
 	}
 

--- a/pkg/persistence/main_test.go
+++ b/pkg/persistence/main_test.go
@@ -19,7 +19,7 @@ var (
 func TestMain(m *testing.M)  {
 
 	// Initialise Authenticator object
-	os.Setenv("KEY_CLAIM_TOKEN", token1 +"=" + onApi + ":"+ token2 +"=302")
+	os.Setenv("KEY_CLAIM_TOKEN", token1 +"=" + onApi + ":"+ token2 +"=428")
 
 	config.InitConfig()
 	SetupLookup(keyclaim.NewAuthenticator())

--- a/pkg/persistence/queries_test.go
+++ b/pkg/persistence/queries_test.go
@@ -241,7 +241,7 @@ func TestPersistEncryptionKey(t *testing.T) {
 	db, mock, _ := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 	defer db.Close()
 
-	region := "302"
+	region := "428"
 	originator := "randomOrigin"
 	pub, priv, _ := box.GenerateKey(rand.Reader)
 	oneTimeCode := "80311300"
@@ -295,7 +295,7 @@ func testPersistEncryptionKeyWithHashID(t *testing.T) {
 	db, mock, _ := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 	defer db.Close()
 
-	region := "302"
+	region := "428"
 	originator := "randomOrigin"
 	pub, priv, _ := box.GenerateKey(rand.Reader)
 	oneTimeCode := "80311300"
@@ -486,7 +486,7 @@ func TestDiagnosisKeysForHours(t *testing.T) {
 	db, mock, _ := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 	defer db.Close()
 
-	region := "302"
+	region := "428"
 	startHour := uint32(100)
 	endHour := uint32(200)
 	currentRollingStartIntervalNumber := int32(2651450)
@@ -500,14 +500,14 @@ func TestDiagnosisKeysForHours(t *testing.T) {
 		AND region = ?
 		ORDER BY key_data`
 
-	row := sqlmock.NewRows([]string{"region", "key_data", "rolling_start_interval_number", "rolling_period", "transmission_risk_level"}).AddRow("302", []byte{}, 2651450, 144, 4)
+	row := sqlmock.NewRows([]string{"region", "key_data", "rolling_start_interval_number", "rolling_period", "transmission_risk_level"}).AddRow("428", []byte{}, 2651450, 144, 4)
 	mock.ExpectQuery(query).WithArgs(
 		startHour,
 		endHour,
 		minRollingStartIntervalNumber,
 		region).WillReturnRows(row)
 
-	expectedResult := []byte("302")
+	expectedResult := []byte("428")
 	rows, _ := diagnosisKeysForHours(db, region, startHour, endHour, currentRollingStartIntervalNumber)
 	var receivedResult []byte
 	for rows.Next() {
@@ -527,7 +527,7 @@ func TestRegisterDiagnosisKeys(t *testing.T) {
 
 	pub, _, _ := box.GenerateKey(rand.Reader)
 	keys := []*pb.TemporaryExposureKey{}
-	region := "302"
+	region := "428"
 	originator := "randomOrigin"
 
 	// Roll back if table is locked
@@ -559,7 +559,7 @@ func TestRegisterDiagnosisKeys(t *testing.T) {
 
 	// Roll back if prepare fails
 	mock.ExpectBegin()
-	row = sqlmock.NewRows([]string{"region", "originator", "remaining_keys"}).AddRow("302", "randomOrigin", 1)
+	row = sqlmock.NewRows([]string{"region", "originator", "remaining_keys"}).AddRow("428", "randomOrigin", 1)
 	mock.ExpectQuery(`SELECT region, originator, remaining_keys FROM encryption_keys WHERE app_public_key = ? FOR UPDATE`).WillReturnRows(row)
 	mock.ExpectPrepare(
 		`INSERT IGNORE INTO diagnosis_keys
@@ -584,7 +584,7 @@ func TestRegisterDiagnosisKeys(t *testing.T) {
 	hourOfSubmission := timemath.HourNumber(time.Now())
 
 	mock.ExpectBegin()
-	row = sqlmock.NewRows([]string{"region", "originator", "remaining_keys"}).AddRow("302", "randomOrigin", 1)
+	row = sqlmock.NewRows([]string{"region", "originator", "remaining_keys"}).AddRow("428", "randomOrigin", 1)
 	mock.ExpectQuery(`SELECT region, originator, remaining_keys FROM encryption_keys WHERE app_public_key = ? FOR UPDATE`).WillReturnRows(row)
 	mock.ExpectPrepare(
 		`INSERT IGNORE INTO diagnosis_keys
@@ -618,7 +618,7 @@ func TestRegisterDiagnosisKeys(t *testing.T) {
 	hourOfSubmission = timemath.HourNumber(time.Now())
 
 	mock.ExpectBegin()
-	row = sqlmock.NewRows([]string{"region", "originator", "remaining_keys"}).AddRow("302", "randomOrigin", 1)
+	row = sqlmock.NewRows([]string{"region", "originator", "remaining_keys"}).AddRow("428", "randomOrigin", 1)
 	mock.ExpectQuery(`SELECT region, originator, remaining_keys FROM encryption_keys WHERE app_public_key = ? FOR UPDATE`).WillReturnRows(row)
 
 	mock.ExpectPrepare(
@@ -659,7 +659,7 @@ func TestRegisterDiagnosisKeys(t *testing.T) {
 	hourOfSubmission = timemath.HourNumber(time.Now())
 
 	mock.ExpectBegin()
-	row = sqlmock.NewRows([]string{"region", "originator", "remaining_keys"}).AddRow("302", "randomOrigin", 3)
+	row = sqlmock.NewRows([]string{"region", "originator", "remaining_keys"}).AddRow("428", "randomOrigin", 3)
 	mock.ExpectQuery(`SELECT region, originator, remaining_keys FROM encryption_keys WHERE app_public_key = ? FOR UPDATE`).WillReturnRows(row)
 
 	mock.ExpectPrepare(
@@ -722,7 +722,7 @@ func TestRegisterDiagnosisKeys(t *testing.T) {
 	hourOfSubmission = timemath.HourNumber(time.Now())
 
 	mock.ExpectBegin()
-	row = sqlmock.NewRows([]string{"region", "originator", "remaining_keys"}).AddRow("302", "randomOrigin", config.AppConstants.InitialRemainingKeys)
+	row = sqlmock.NewRows([]string{"region", "originator", "remaining_keys"}).AddRow("428", "randomOrigin", config.AppConstants.InitialRemainingKeys)
 	mock.ExpectQuery(`SELECT region, originator, remaining_keys FROM encryption_keys WHERE app_public_key = ? FOR UPDATE`).WillReturnRows(row)
 
 	mock.ExpectPrepare(

--- a/pkg/retrieval/authenticator_test.go
+++ b/pkg/retrieval/authenticator_test.go
@@ -65,7 +65,7 @@ func TestAuthenticate(t *testing.T) {
 	os.Setenv("RETRIEVE_HMAC_KEY", validHmacKey)
 	authenticator := NewAuthenticator()
 
-	validRegion := "302"
+	validRegion := "428"
 	validDay := "18444"
 	validAuth := "448d9bfd238b34323b70175b4b385fb39d59186711049c6766fa7c890de33a12"
 

--- a/pkg/retrieval/retrieval.go
+++ b/pkg/retrieval/retrieval.go
@@ -21,7 +21,7 @@ const (
 var (
 	signatureAlgorithm     = "1.2.840.10045.4.3.2" // required by protocol
 	verificationKeyVersion = "v1"
-	verificationKeyID      = "302"
+	verificationKeyID      = "428"
 	binHeader              = []byte("EK Export v1    ")
 	binHeaderLength        = 16
 )
@@ -37,7 +37,7 @@ func min(a, b int) int {
 // expected/permitted to use some other identifier. It would be great to get
 // more clarity on this.
 func transformRegion(reg string) string {
-	if reg == "302" {
+	if reg == "428" {
 		return "CA"
 	}
 	return reg

--- a/pkg/retrieval/retrieval_test.go
+++ b/pkg/retrieval/retrieval_test.go
@@ -36,7 +36,7 @@ func TestMin(t *testing.T) {
 
 func TestTransformRegion(t *testing.T) {
 
-	reg := "302"
+	reg := "428"
 	regBadOtherInt := "1233"
 	regBadString := "foo"
 
@@ -53,7 +53,7 @@ func TestSerializeTo(t *testing.T) {
 	req, _ := http.NewRequest("POST", "/", nil)
 	ctx := req.Context()
 	resp := httptest.NewRecorder()
-	region := "302"
+	region := "428"
 	keys := []*pb.TemporaryExposureKey{randomTestKey(), randomTestKey()}
 	startTimestamp := time.Now()
 	endTimestamp := time.Now().Add(1 * time.Hour)

--- a/pkg/server/keyclaim_test.go
+++ b/pkg/server/keyclaim_test.go
@@ -130,11 +130,11 @@ func TestGoodAuthToken_NoHashID(t *testing.T){
 	auth := &keyclaim.Authenticator{}
 
 	// Auth Mock
-	auth.On("Authenticate", "goodtoken").Return("302", true)
-	auth.On("RegionFromAuthHeader", "Bearer goodtoken").Return("302", "goodtoken", true)
+	auth.On("Authenticate", "goodtoken").Return("428", true)
+	auth.On("RegionFromAuthHeader", "Bearer goodtoken").Return("428", "goodtoken", true)
 
 	// DB Mock
-	db.On("NewKeyClaim", mock.Anything, "302", "goodtoken", "").Return("AAABBBCCCC", nil)
+	db.On("NewKeyClaim", mock.Anything, "428", "goodtoken", "").Return("AAABBBCCCC", nil)
 
 
 	router := buildNewKeyClaimServletRouter(db, auth)
@@ -157,12 +157,12 @@ func TestGoodAuthToken_HashID(t *testing.T) {
 	auth := &keyclaim.Authenticator{}
 
 	// Auth Mock
-	auth.On("Authenticate", "goodtoken").Return("302", true)
-	auth.On("RegionFromAuthHeader", "Bearer goodtoken").Return("302", "goodtoken", true)
+	auth.On("Authenticate", "goodtoken").Return("428", true)
+	auth.On("RegionFromAuthHeader", "Bearer goodtoken").Return("428", "goodtoken", true)
 
 	hashID := hex.EncodeToString(SHA512([]byte("abcd")))
 	// DB Mock
-	db.On("NewKeyClaim", mock.Anything, "302", "goodtoken", hashID).Return("AAABBBCCCC", nil)
+	db.On("NewKeyClaim", mock.Anything, "428", "goodtoken", hashID).Return("AAABBBCCCC", nil)
 
 	router := buildNewKeyClaimServletRouter(db, auth)
 	_, oldLog := testhelpers.SetupTestLogging(&log)
@@ -182,11 +182,11 @@ func TestGoodAuthToken_HashID(t *testing.T) {
 func Test_ErrorSavingNoHashID(t *testing.T) {
 
 	auth := &keyclaim.Authenticator{}
-	auth.On("Authenticate", "errortoken").Return("302", true)
-	auth.On("RegionFromAuthHeader", "Bearer errortoken").Return("302", "errortoken", true)
+	auth.On("Authenticate", "errortoken").Return("428", true)
+	auth.On("RegionFromAuthHeader", "Bearer errortoken").Return("428", "errortoken", true)
 
 	db := &persistence.Conn{}
-	db.On("NewKeyClaim", mock.Anything, "302", "errortoken", "").Return("", fmt.Errorf("Random error"))
+	db.On("NewKeyClaim", mock.Anything, "428", "errortoken", "").Return("", fmt.Errorf("Random error"))
 
 	router := buildNewKeyClaimServletRouter(db, auth)
 
@@ -209,12 +209,12 @@ func Test_ErrorSavingNoHashID(t *testing.T) {
 func TestNewKeyClaimErrorSavingDuplicateHashID(t *testing.T) {
 
 	auth := &keyclaim.Authenticator{}
-	auth.On("Authenticate", "errortoken").Return("302", true)
-	auth.On("RegionFromAuthHeader", "Bearer errortoken").Return("302", "errortoken", true)
+	auth.On("Authenticate", "errortoken").Return("428", true)
+	auth.On("RegionFromAuthHeader", "Bearer errortoken").Return("428", "errortoken", true)
 
 	hashID := hex.EncodeToString(SHA512([]byte("abcd")))
 	db := &persistence.Conn{}
-	db.On("NewKeyClaim", mock.Anything, "302", "errortoken", hashID).Return("", err.ErrHashIDClaimed)
+	db.On("NewKeyClaim", mock.Anything, "428", "errortoken", hashID).Return("", err.ErrHashIDClaimed)
 
 	router := buildNewKeyClaimServletRouter(db, auth)
 	hook, oldLog := testhelpers.SetupTestLogging(&log)

--- a/pkg/server/retrieve.go
+++ b/pkg/server/retrieve.go
@@ -59,7 +59,7 @@ func (s *retrieveServlet) retrieve(w http.ResponseWriter, r *http.Request) resul
 	ctx := r.Context()
 	vars := mux.Vars(r)
 
-	/* Hardcode the region as 302 (Canada MCC)
+	/* Hardcode the region as 428 (Mongolia MCC)
 	You can see the reason for this in pkg/server/keyclaim.go
 	As stated there I'm going to open an issue to continue this work instead of just
 	relying on the hardcoded value.

--- a/pkg/server/retrieve_test.go
+++ b/pkg/server/retrieve_test.go
@@ -63,7 +63,7 @@ func TestRetrieve(t *testing.T) {
 	auth := &retrieval.Authenticator{}
 	signer := &retrieval.Signer{}
 
-	region := "302"
+	region := "428"
 	goodAuth := "abcd"
 	badAuth := "dcba"
 	currentRSIN := pb.CurrentRollingStartIntervalNumber()

--- a/proto/README.md
+++ b/proto/README.md
@@ -88,7 +88,7 @@ encryption and authorization will become invalid and be purged.
 
 ## `/retrieve/:region/:datenumber/:hmac`
 
-The `region` is an [MCC](https://www.mcc-mnc.com/) (e.g. "302" for Canada).
+The `region` is an [MCC](https://www.mcc-mnc.com/) (e.g. "428" for Mongolia).
 
 A "date number" in this system is a UTC timestamp divided (using integer division) by 86400. This
 quantity increases by 1 each day, at UTC midnight.

--- a/sample.docker-compose.yml
+++ b/sample.docker-compose.yml
@@ -30,7 +30,7 @@ services:
       DATABASE_URL: UserName:Password@tcp(mysql)/DatabaseName
       ECDSA_KEY: 30770201010420a6885a310b694b7bb4ba985459de1e79446dddcd1247c62ece925402b362a110a00a06082a8648ce3d030107a1440342000403eb64f714c4b4ed394331c26c31b7ce7156d00fb28982ad2679a87eaa1a3869802fbeb1d7ee28002762921929c3f7603672d535fcac3d24d57afbb4e2d97f5a
       RETRIEVE_HMAC_KEY: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-      KEY_CLAIM_TOKEN: thisisaverylongtoken=302
+      KEY_CLAIM_TOKEN: thisisaverylongtoken=428
       TRACER_PROVIDER: ""
       METRIC_PROVIDER: stdout
       METRICS_USERNAME: 1234567890
@@ -55,7 +55,7 @@ services:
     restart: always
     environment:
       DATABASE_URL: UserName:Password@tcp(mysql)/DatabaseName
-      KEY_CLAIM_TOKEN: thisisaverylongtoken=302
+      KEY_CLAIM_TOKEN: thisisaverylongtoken=428
       TRACER_PROVIDER: ""
       METRIC_PROVIDER: stdout
       METRICS_USERNAME: 1234567890

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -60,9 +60,9 @@ module Helper
       hmac = OpenSSL::HMAC.hexdigest(
         "SHA256",
         [ENV.fetch("RETRIEVE_HMAC_KEY")].pack("H*"),
-        "302:#{date_number}:#{Time.now.to_i / 3600}"
+        "428:#{date_number}:#{Time.now.to_i / 3600}"
       )
-      @ret_conn.send(method, "/retrieve/302/#{date_number}/#{hmac}")
+      @ret_conn.send(method, "/retrieve/428/#{date_number}/#{hmac}")
     end
 
     def tek(data: '1' * 16, transmission_risk_level: 3, rolling_period: 144, rolling_start_interval_number: next_rsin)
@@ -208,7 +208,7 @@ module Helper
       pid = Process.spawn(
         {
           'BIND_ADDR' => addr,
-          'KEY_CLAIM_TOKEN' => 'first-very-long-token=302:second-very-long-token=302',
+          'KEY_CLAIM_TOKEN' => 'first-very-long-token=428:second-very-long-token=428',
           'DATABASE_URL' => DATABASE_URL,
         },
         bin, STDERR => File.open('/dev/null')

--- a/test/retrieve_test.rb
+++ b/test/retrieve_test.rb
@@ -169,23 +169,23 @@ class RetrieveTest < MiniTest::Test
     hmac = OpenSSL::HMAC.hexdigest(
       "SHA256",
       [ENV.fetch("RETRIEVE_HMAC_KEY")].pack("H*"),
-      "302:#{dn}:#{Time.now.to_i / 3600}"
+      "428:#{dn}:#{Time.now.to_i / 3600}"
     )
 
     # success
-    resp = @ret_conn.get("/retrieve/302/#{dn}/#{hmac}")
+    resp = @ret_conn.get("/retrieve/428/#{dn}/#{hmac}")
     assert_response(resp, 200, 'application/zip')
 
     # hmac is keyed to date
-    resp = @ret_conn.get("/retrieve/302/#{dn - 1}/#{hmac}")
+    resp = @ret_conn.get("/retrieve/428/#{dn - 1}/#{hmac}")
     assert_response(resp, 401, 'text/plain; charset=utf-8', body: "unauthorized\n")
 
     # changing hmac breaks it
-    resp = @ret_conn.get("/retrieve/302/#{dn}/11112222#{hmac[8..-1]}")
+    resp = @ret_conn.get("/retrieve/428/#{dn}/11112222#{hmac[8..-1]}")
     assert_response(resp, 401, 'text/plain; charset=utf-8', body: "unauthorized\n")
 
     # hmac is required
-    resp = @ret_conn.get("/retrieve/302/#{dn}")
+    resp = @ret_conn.get("/retrieve/428/#{dn}")
     assert_response(resp, 404, 'text/plain; charset=utf-8', body: "404 page not found\n")
   end
 
@@ -274,7 +274,7 @@ class RetrieveTest < MiniTest::Test
     assert_equal([], files, "  (from #{caller[0]})")
   end
 
-  def add_key(data: '1' * 16, active_at:, submitted_at:, transmission_risk_level: 8, region: '302')
+  def add_key(data: '1' * 16, active_at:, submitted_at:, transmission_risk_level: 8, region: '428')
     add_key_explicit(
       rsin: rolling_start_interval_number(active_at),
       hour: hour_number(submitted_at),
@@ -292,7 +292,7 @@ class RetrieveTest < MiniTest::Test
     SQL
   end
 
-  def add_key_explicit(data: '1' * 16, rsin:, transmission_risk_level: 8, hour:, region: '302', rolling_period: TEK_ROLLING_PERIOD)
+  def add_key_explicit(data: '1' * 16, rsin:, transmission_risk_level: 8, hour:, region: '428', rolling_period: TEK_ROLLING_PERIOD)
     insert_key.execute(data, rsin, rolling_period, transmission_risk_level, hour, region)
   end
 
@@ -330,7 +330,7 @@ class RetrieveTest < MiniTest::Test
         signature_infos: [
           Covidshield::SignatureInfo.new(
             verification_key_version: "v1",
-            verification_key_id: "302",
+            verification_key_id: "428",
             signature_algorithm: "1.2.840.10045.4.3.2"
           ),
         ],
@@ -349,7 +349,7 @@ class RetrieveTest < MiniTest::Test
           Covidshield::TEKSignature.new(
             signature_info: Covidshield::SignatureInfo.new(
               verification_key_version: "v1",
-              verification_key_id: "302",
+              verification_key_id: "428",
               signature_algorithm: "1.2.840.10045.4.3.2"
             ),
             batch_num: 1,


### PR DESCRIPTION
Fixes:

## Description of what your PR accomplishes:

Update MCC code to `428` which reflects Mongolia. Reference: https://www.mcc-mnc.com/

## Why this approach? Any notable design decisions?

Currently, all default region values are set to `302` which represents Canada. We should have the proper, corresponding Mobile Country Code.

## Anything the reviewers should focus on? Any discussion points?

Just the `428` and syntax to make sure no quotes/syntax are broke.